### PR TITLE
removed draggabel placeholder as it is causing height bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17150,7 +17150,8 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/src/components/DayCard/DayCard.js
+++ b/src/components/DayCard/DayCard.js
@@ -76,7 +76,6 @@ const DayCard = (props) => {
                 </Grid>
               </Paper>
             </div>
-            {provided.placeholder}
           </div>
         )}
       </Droppable>


### PR DESCRIPTION
This code takes out the draggable placeholder. This fixes the bug of the day cards moving up. This also starts throwing the warning about the placeholder being required. The source and original indexes are still accurate. I am not sure why the placeholder is required but for now, I will remove it.